### PR TITLE
fixed link to passwordless-auth-client post

### DIFF
--- a/content/posts/passwordless-auth-server.md
+++ b/content/posts/passwordless-auth-server.md
@@ -727,4 +727,5 @@ I had this problem sometimes on `localhost`, but I think you should be fine once
 
 [Source Code](https://github.com/nicolasparada/go-passwordless-demo). • [Demo](https://go-passwordless-demo.herokuapp.com/).
 
-I~~'ll write~~ wrote a [second part]((/posts/passwordless-auth-client/)) for this post coding a JavaScript client for the API.
+I wrote a [second part](/posts/passwordless-auth-client/) for this post coding a JavaScript client for the API.
+~


### PR DESCRIPTION
I was reading your blogpost and saw that the link to the second part was broken.

While there, edited out the strike through since the tildes showed up literally in the output (instead of marking the words as strikethrough) 